### PR TITLE
feat(driver): add Mailtrap Email API driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@
 
 ## Design goals
 
-| Goal                         | How `unemail` delivers                                                                                                                                                    |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **One API, many transports** | `createEmail({ driver })` — 15+ built-in drivers (SMTP, Resend, SES, Postmark, SendGrid, Mailgun, Brevo, MailerSend, Loops, Zeptomail, MailChannels, Cloudflare Email, …) |
-| **Cross-runtime**            | Node, Bun, Deno, Cloudflare Workers, browser — core is zero-dep and Web-API only. No `axios`, ever.                                                                       |
-| **Compliance-ready**         | RFC 8058 one-click List-Unsubscribe, DKIM + ARC signing, suppression/preference stores, DMARC + TLS-RPT + ARF parsers                                                     |
-| **Resilient by default**     | Idempotency, retry w/ jitter, per-provider rate-limit, circuit breaker, dedupe, dead-letter, provider fallback                                                            |
-| **Unified observability**    | Structured logging, OpenTelemetry, Prometheus metrics, normalized `EmailEvent` stream across send + webhook paths                                                         |
-| **Modern DX**                | `{ data, error }` Result discriminated union, typed `Address` primitive, `react:`/`mjml:`/`handlebars:`/`liquid:` props                                                   |
-| **Testing-first**            | `createTestEmail()` with inbox + `waitFor` + 5 Vitest matchers + snapshot helper                                                                                          |
+| Goal                         | How `unemail` delivers                                                                                                                                                              |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **One API, many transports** | `createEmail({ driver })` — 15+ built-in drivers (SMTP, Resend, SES, Postmark, SendGrid, Mailgun, Mailtrap, Brevo, MailerSend, Loops, Zeptomail, MailChannels, Cloudflare Email, …) |
+| **Cross-runtime**            | Node, Bun, Deno, Cloudflare Workers, browser — core is zero-dep and Web-API only. No `axios`, ever.                                                                                 |
+| **Compliance-ready**         | RFC 8058 one-click List-Unsubscribe, DKIM + ARC signing, suppression/preference stores, DMARC + TLS-RPT + ARF parsers                                                               |
+| **Resilient by default**     | Idempotency, retry w/ jitter, per-provider rate-limit, circuit breaker, dedupe, dead-letter, provider fallback                                                                      |
+| **Unified observability**    | Structured logging, OpenTelemetry, Prometheus metrics, normalized `EmailEvent` stream across send + webhook paths                                                                   |
+| **Modern DX**                | `{ data, error }` Result discriminated union, typed `Address` primitive, `react:`/`mjml:`/`handlebars:`/`liquid:` props                                                             |
+| **Testing-first**            | `createTestEmail()` with inbox + `waitFor` + 5 Vitest matchers + snapshot helper                                                                                                    |
 
 ## Install
 

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -16,6 +16,7 @@ touch it again; swapping providers is a one-line change.
 | `unemail/driver/ses`              | all (Web-Crypto)   |      ✓      | ✓ (seq) |     –      |      –      |     –     |  ✓   |    –    |
 | `unemail/driver/sendgrid`         | all                |      ✓      |    –    |     ✓      |      –      |     ✓     |  ✓   |    –    |
 | `unemail/driver/mailgun`          | all                |      ✓      |    –    |     ✓      |      –      |     –     |  ✓   |    –    |
+| `unemail/driver/mailtrap`         | all                |      ✓      |    ✓    |     –      |      –      |     ✓     |  ✓   |    –    |
 | `unemail/driver/brevo`            | all                |      ✓      |    –    |     ✓      |      –      |     ✓     |  ✓   |    –    |
 | `unemail/driver/mailersend`       | all                |      ✓      |    ✓    |     ✓      |      –      |     –     |  ✓   |    –    |
 | `unemail/driver/loops`            | all                |      –      |    –    |     –      |      –      |     ✓     |  ✓   |    –    |

--- a/jsr.json
+++ b/jsr.json
@@ -11,6 +11,7 @@
     "./driver/zeptomail": "./src/driver/zeptomail.ts",
     "./driver/sendgrid": "./src/driver/sendgrid.ts",
     "./driver/mailgun": "./src/driver/mailgun.ts",
+    "./driver/mailtrap": "./src/driver/mailtrap.ts",
     "./driver/brevo": "./src/driver/brevo.ts",
     "./driver/mailersend": "./src/driver/mailersend.ts",
     "./driver/loops": "./src/driver/loops.ts",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "mailcrab",
     "mailersend",
     "mailgun",
+    "mailtrap",
     "mjml",
     "postal-mime",
     "postmark",
@@ -91,6 +92,10 @@
     "./driver/mailgun": {
       "types": "./dist/driver/mailgun.d.mts",
       "default": "./dist/driver/mailgun.mjs"
+    },
+    "./driver/mailtrap": {
+      "types": "./dist/driver/mailtrap.d.mts",
+      "default": "./dist/driver/mailtrap.mjs"
     },
     "./driver/brevo": {
       "types": "./dist/driver/brevo.d.mts",

--- a/src/driver/_http.ts
+++ b/src/driver/_http.ts
@@ -2,7 +2,7 @@ import type { Result } from "../types.ts"
 import { createError, toEmailError } from "../errors.ts"
 
 /** Thin wrapper around `fetch` used by every HTTP-based driver (Resend,
- *  Postmark, SendGrid, Mailgun, Brevo, MailerSend, Loops, Zeptomail,
+ *  Postmark, SendGrid, Mailgun, Mailtrap, Brevo, MailerSend, Loops, Zeptomail,
  *  MailChannels, HTTP). Handles JSON encoding, response parsing, and
  *  mapping HTTP status codes to our `EmailErrorCode` taxonomy.
  *

--- a/src/driver/mailtrap.ts
+++ b/src/driver/mailtrap.ts
@@ -1,0 +1,303 @@
+import type {
+  Attachment,
+  DriverFactory,
+  EmailAddress,
+  EmailMessage,
+  EmailResult,
+  EmailTag,
+  Result,
+} from "../types.ts"
+import { defineDriver } from "../_define.ts"
+import { normalizeAddresses } from "../_normalize.ts"
+import { createError, createRequiredError } from "../errors.ts"
+import { httpJson } from "./_http.ts"
+
+export interface MailtrapDriverOptions {
+  apiKey: string
+  endpoint?: string
+  fetch?: typeof fetch
+  /** Used when no \`tags\` entry has \`name: "category"\`. */
+  defaultCategory?: string
+  /** Mailtrap edge protection may block requests without a User-Agent. */
+  userAgent?: string
+}
+
+interface MailtrapSendSuccess {
+  success?: boolean
+  message_ids?: string[]
+  errors?: string[]
+}
+
+interface MailtrapBatchItemResponse {
+  success?: boolean
+  message_ids?: string[]
+  errors?: string[]
+}
+
+interface MailtrapBatchSuccess {
+  success?: boolean
+  responses?: MailtrapBatchItemResponse[]
+  errors?: string[]
+}
+
+const DRIVER = "mailtrap"
+const DEFAULT_ENDPOINT = "https://send.api.mailtrap.io"
+
+const mailtrap: DriverFactory<MailtrapDriverOptions> = defineDriver<MailtrapDriverOptions>(
+  (options) => {
+    if (!options?.apiKey) throw createRequiredError(DRIVER, "apiKey")
+
+    const endpoint = options.endpoint ?? DEFAULT_ENDPOINT
+    const fetchImpl = options.fetch ?? globalThis.fetch
+    if (typeof fetchImpl !== "function")
+      throw createError(DRIVER, "INVALID_OPTIONS", "fetch is unavailable; pass `fetch` explicitly")
+
+    const defaultCategory = options.defaultCategory ?? "transactional"
+    const userAgent = options.userAgent ?? "unemail/mailtrap"
+
+    const mailtrapHeaders = (): Record<string, string> => ({
+      "api-token": options.apiKey,
+      "user-agent": userAgent,
+    })
+
+    return {
+      name: DRIVER,
+      options,
+      flags: {
+        attachments: true,
+        html: true,
+        text: true,
+        batch: true,
+        templates: true,
+        replyTo: true,
+        customHeaders: true,
+      },
+
+      async isAvailable() {
+        return Boolean(options.apiKey)
+      },
+
+      async send(msg) {
+        const unsupported = rejectUnsupported(msg)
+        if (unsupported) return unsupported
+
+        const payload = buildPayload(msg, defaultCategory)
+        const res = await httpJson({
+          fetch: fetchImpl,
+          driver: DRIVER,
+          url: `${endpoint}/api/send`,
+          headers: mailtrapHeaders(),
+          body: payload,
+          classifyError: classifyMailtrapError,
+        })
+        if (res.error) return res as Result<EmailResult>
+        return parseSendSuccess(res.data)
+      },
+
+      async sendBatch(msgs) {
+        if (msgs.length === 0) return { data: [], error: null }
+        for (const msg of msgs) {
+          const unsupported = rejectUnsupported(msg)
+          if (unsupported) return unsupported as Result<ReadonlyArray<EmailResult>>
+        }
+
+        const payload = {
+          requests: msgs.map((m) => buildPayload(m, defaultCategory)),
+        }
+        const res = await httpJson({
+          fetch: fetchImpl,
+          driver: DRIVER,
+          url: `${endpoint}/api/batch`,
+          headers: mailtrapHeaders(),
+          body: payload,
+          classifyError: classifyMailtrapError,
+        })
+        if (res.error) return res as never
+
+        const body = (res.data ?? {}) as MailtrapBatchSuccess
+        if (body.success === false) {
+          return {
+            data: null,
+            error: createError(
+              DRIVER,
+              "PROVIDER",
+              formatErrors(body.errors) ?? "batch request failed",
+              { cause: body },
+            ),
+          }
+        }
+
+        const responses = body.responses ?? []
+        for (let i = 0; i < responses.length; i++) {
+          const item = responses[i]
+          if (item?.success === false) {
+            return {
+              data: null,
+              error: createError(
+                DRIVER,
+                "PROVIDER",
+                formatErrors(item.errors) || `batch item ${i} failed`,
+                { cause: item },
+              ),
+            }
+          }
+        }
+
+        const results: EmailResult[] = responses.map((item, i) => ({
+          id: item?.message_ids?.[0] ?? `mailtrap_${Date.now().toString(36)}_${i}`,
+          driver: DRIVER,
+          at: new Date(),
+          provider: item as unknown as Record<string, unknown>,
+        }))
+        return { data: results, error: null }
+      },
+    }
+  },
+)
+
+export default mailtrap
+
+function rejectUnsupported(msg: EmailMessage): Result<EmailResult> | null {
+  if (msg.scheduledAt) {
+    return {
+      data: null,
+      error: createError(DRIVER, "UNSUPPORTED", "scheduling is not supported by Mailtrap", {
+        retryable: false,
+      }),
+    }
+  }
+  return null
+}
+
+function parseSendSuccess(data: unknown): Result<EmailResult> {
+  const body = (data ?? {}) as MailtrapSendSuccess
+  if (body.success === false) {
+    return {
+      data: null,
+      error: createError(DRIVER, "PROVIDER", formatErrors(body.errors) ?? "send failed", {
+        cause: body,
+      }),
+    }
+  }
+  const id = body.message_ids?.[0] ?? `mailtrap_${Date.now().toString(36)}`
+  return {
+    data: {
+      id,
+      driver: DRIVER,
+      at: new Date(),
+      provider: body as Record<string, unknown>,
+    },
+    error: null,
+  }
+}
+
+function classifyMailtrapError(
+  status: number,
+  body: unknown,
+): {
+  code: "AUTH" | "RATE_LIMIT" | "NETWORK" | "PROVIDER"
+  retryable?: boolean
+  message?: string
+} | null {
+  const record = body && typeof body === "object" ? (body as Record<string, unknown>) : null
+  const errors = record?.errors
+  const message =
+    formatErrors(Array.isArray(errors) ? (errors as string[]) : undefined) ??
+    (typeof record?.message === "string" ? record.message : null)
+
+  if (status === 401 || status === 403) {
+    return { code: "AUTH", retryable: false, message: message ?? undefined }
+  }
+  if (status === 429) {
+    return { code: "RATE_LIMIT", retryable: true, message: message ?? undefined }
+  }
+  if (status >= 500) {
+    return { code: "NETWORK", retryable: true, message: message ?? undefined }
+  }
+  if (message) return { code: "PROVIDER", retryable: false, message }
+  return null
+}
+
+function formatErrors(errors: string[] | undefined): string | null {
+  if (!errors?.length) return null
+  return errors.join("; ")
+}
+
+function buildPayload(msg: EmailMessage, defaultCategory: string): Record<string, unknown> {
+  const from = normalizeAddresses(msg.from)[0]
+  if (!from) throw createError(DRIVER, "INVALID_OPTIONS", "`from` is required")
+
+  const payload: Record<string, unknown> = {
+    from: toMailtrapAddress(from),
+    to: normalizeAddresses(msg.to).map(toMailtrapAddress),
+    subject: msg.subject,
+  }
+  if (msg.cc) payload.cc = normalizeAddresses(msg.cc).map(toMailtrapAddress)
+  if (msg.bcc) payload.bcc = normalizeAddresses(msg.bcc).map(toMailtrapAddress)
+  if (msg.replyTo) {
+    const r = normalizeAddresses(msg.replyTo)[0]
+    if (r) payload.reply_to = toMailtrapAddress(r)
+  }
+  if (msg.text) payload.text = msg.text
+  if (msg.html) payload.html = msg.html
+  if (msg.headers) payload.headers = msg.headers
+  if (msg.attachments?.length) payload.attachments = msg.attachments.map(toMailtrapAttachment)
+
+  const customVars: Record<string, string> = {}
+  if (msg.metadata) {
+    for (const [k, v] of Object.entries(msg.metadata)) customVars[k] = String(v)
+  }
+  if (msg.tags?.length) {
+    for (const tag of msg.tags) {
+      if (tag.name === "category") continue
+      customVars[`tag_${tag.name}`] = tag.value ?? ""
+    }
+  }
+  if (Object.keys(customVars).length) payload.custom_variables = customVars
+
+  payload.category = resolveCategory(msg.tags, defaultCategory)
+
+  if (msg.template) {
+    if (msg.template.id) payload.template_uuid = msg.template.id
+    if (msg.template.variables) payload.template_variables = { ...msg.template.variables }
+  }
+
+  if (!msg.template && !msg.text && !msg.html) {
+    throw createError(DRIVER, "INVALID_OPTIONS", "`text`, `html`, or `template` is required")
+  }
+
+  return payload
+}
+
+function resolveCategory(tags: ReadonlyArray<EmailTag> | undefined, fallback: string): string {
+  const cat = tags?.find((t) => t.name === "category")
+  if (cat?.value) return cat.value
+  if (cat?.name === "category" && !cat.value) return fallback
+  return fallback
+}
+
+function toMailtrapAddress(a: EmailAddress): Record<string, string> {
+  return a.name ? { email: a.email, name: a.name } : { email: a.email }
+}
+
+function toMailtrapAttachment(a: Attachment): Record<string, unknown> {
+  const content = typeof a.content === "string" ? a.content : bytesToBase64(a.content)
+  const out: Record<string, unknown> = {
+    content,
+    filename: a.filename,
+  }
+  if (a.contentType) out.type = a.contentType
+  if (a.disposition) out.disposition = a.disposition
+  if (a.cid) out.content_id = a.cid
+  return out
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  const g = globalThis as {
+    Buffer?: { from: (b: Uint8Array) => { toString: (e: string) => string } }
+  }
+  if (g.Buffer) return g.Buffer.from(bytes).toString("base64")
+  let binary = ""
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary)
+}

--- a/test/driver/mailtrap.test.ts
+++ b/test/driver/mailtrap.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest"
+import { createEmail } from "../../src/index.ts"
+import mailtrap from "../../src/driver/mailtrap.ts"
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+describe("mailtrap driver", () => {
+  it("POSTs /api/send with Api-Token and address shape", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ success: true, message_ids: ["mt_1"] }))
+    const email = createEmail({
+      driver: mailtrap({ apiKey: "token", fetch: fetchMock as unknown as typeof fetch }),
+    })
+    const { data, error } = await email.send({
+      from: "Acme <hi@acme.com>",
+      to: "user@example.com",
+      subject: "hi",
+      text: "hello",
+    })
+    expect(error).toBeNull()
+    expect(data?.id).toBe("mt_1")
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe("https://send.api.mailtrap.io/api/send")
+    const headers = init.headers as Record<string, string>
+    expect(headers["api-token"]).toBe("token")
+    expect(headers["user-agent"]).toBe("unemail/mailtrap")
+    const body = JSON.parse(init.body as string)
+    expect(body.from).toEqual({ email: "hi@acme.com", name: "Acme" })
+    expect(body.to).toEqual([{ email: "user@example.com" }])
+    expect(body.category).toBe("transactional")
+  })
+
+  it("maps category tag and extra tags to custom_variables", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ success: true, message_ids: ["x"] }))
+    const email = createEmail({
+      driver: mailtrap({ apiKey: "k", fetch: fetchMock as unknown as typeof fetch }),
+    })
+    await email.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "x",
+      text: "x",
+      tags: [
+        { name: "category", value: "password-reset" },
+        { name: "tenant", value: "acme" },
+      ],
+    })
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(init.body as string)
+    expect(body.category).toBe("password-reset")
+    expect(body.custom_variables).toEqual({ tag_tenant: "acme" })
+  })
+
+  it("uses defaultCategory when no category tag", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ success: true, message_ids: ["x"] }))
+    const email = createEmail({
+      driver: mailtrap({
+        apiKey: "k",
+        defaultCategory: "notifications",
+        fetch: fetchMock as unknown as typeof fetch,
+      }),
+    })
+    await email.send({ from: "a@b.com", to: "c@d.com", subject: "x", text: "x" })
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(init.body as string)
+    expect(body.category).toBe("notifications")
+  })
+
+  it("rejects missing apiKey at factory time", () => {
+    expect(() => mailtrap({} as { apiKey: string })).toThrow(/apiKey/)
+  })
+
+  it("maps 401 to AUTH", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ success: false, errors: ["Unauthorized"] }, 401))
+    const email = createEmail({
+      driver: mailtrap({ apiKey: "k", fetch: fetchMock as unknown as typeof fetch }),
+    })
+    const { error } = await email.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "x",
+      text: "x",
+    })
+    expect(error?.code).toBe("AUTH")
+    expect(error?.retryable).toBe(false)
+  })
+
+  it("maps 429 to RATE_LIMIT", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ success: false, errors: ["Too many requests"] }, 429))
+    const email = createEmail({
+      driver: mailtrap({ apiKey: "k", fetch: fetchMock as unknown as typeof fetch }),
+    })
+    const { error } = await email.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "x",
+      text: "x",
+    })
+    expect(error?.code).toBe("RATE_LIMIT")
+    expect(error?.retryable).toBe(true)
+  })
+
+  it("returns PROVIDER when HTTP 200 but success is false", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ success: false, errors: ["Invalid from"] }))
+    const email = createEmail({
+      driver: mailtrap({ apiKey: "k", fetch: fetchMock as unknown as typeof fetch }),
+    })
+    const { error } = await email.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "x",
+      text: "x",
+    })
+    expect(error?.code).toBe("PROVIDER")
+    expect(error?.message).toContain("Invalid from")
+  })
+
+  it("returns UNSUPPORTED for scheduledAt", async () => {
+    const fetchMock = vi.fn()
+    const email = createEmail({
+      driver: mailtrap({ apiKey: "k", fetch: fetchMock as unknown as typeof fetch }),
+    })
+    const { error } = await email.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "x",
+      text: "x",
+      scheduledAt: new Date(),
+    })
+    expect(error?.code).toBe("UNSUPPORTED")
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("sendBatch POSTs /api/batch with requests array", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        success: true,
+        responses: [
+          { success: true, message_ids: ["a"] },
+          { success: true, message_ids: ["b"] },
+        ],
+      }),
+    )
+    const email = createEmail({
+      driver: mailtrap({ apiKey: "k", fetch: fetchMock as unknown as typeof fetch }),
+    })
+    const { data, error } = await email.sendBatch([
+      { from: "a@b.com", to: "x@y.com", subject: "1", text: "x" },
+      { from: "a@b.com", to: "y@y.com", subject: "2", text: "x" },
+    ])
+    expect(error).toBeNull()
+    expect(data).toHaveLength(2)
+    expect(data?.[0]?.id).toBe("a")
+    expect(data?.[1]?.id).toBe("b")
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toBe("https://send.api.mailtrap.io/api/batch")
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(init.body as string)
+    expect(body.requests).toHaveLength(2)
+  })
+
+  it("sendBatch fails when a batch item has success false", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        success: true,
+        responses: [
+          { success: true, message_ids: ["a"] },
+          { success: false, errors: ["bad"] },
+        ],
+      }),
+    )
+    const email = createEmail({
+      driver: mailtrap({ apiKey: "k", fetch: fetchMock as unknown as typeof fetch }),
+    })
+    const { error } = await email.sendBatch([
+      { from: "a@b.com", to: "x@y.com", subject: "1", text: "x" },
+      { from: "a@b.com", to: "y@y.com", subject: "2", text: "x" },
+    ])
+    expect(error?.code).toBe("PROVIDER")
+  })
+})

--- a/test/driver/templates.test.ts
+++ b/test/driver/templates.test.ts
@@ -7,6 +7,7 @@ import brevo from "../../src/driver/brevo.ts"
 import mailersend from "../../src/driver/mailersend.ts"
 import loops from "../../src/driver/loops.ts"
 import zeptomail from "../../src/driver/zeptomail.ts"
+import mailtrap from "../../src/driver/mailtrap.ts"
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -101,6 +102,18 @@ describe("msg.template pass-through across drivers", () => {
     const body = JSON.parse(init.body as string)
     expect(body.transactionalId).toBe("tpl-1")
     expect(body.dataVariables).toEqual({ name: "Ada" })
+  })
+
+  it("mailtrap maps to template_uuid + template_variables", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ success: true, message_ids: ["m"] }))
+    const email = createEmail({
+      driver: mailtrap({ apiKey: "k", fetch: fetchMock as unknown as typeof fetch }),
+    })
+    await email.send(baseMsg)
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(init.body as string)
+    expect(body.template_uuid).toBe("tpl-1")
+    expect(body.template_variables).toEqual({ name: "Ada" })
   })
 
   it("zeptomail maps to template_key + merge_info", async () => {


### PR DESCRIPTION
## Summary

Adds `unemail/driver/mailtrap` for [Mailtrap transactional Email API](https://docs.mailtrap.io/developers/email-sending/transactional).

Closes #96

## Capabilities

| Feature | Supported |
|---------|-----------|
| Send (`POST /api/send`) | yes |
| Batch (`POST /api/batch`, up to 500) | yes |
| Attachments | yes |
| Templates (`template_uuid`) | yes |
| Custom headers / reply-to | yes |
| Category (via `tags` with `name: "category"` or `defaultCategory`) | yes |
| Scheduling / idempotency / webhooks | no (v1) |

## Usage

```ts
import mailtrap from "unemail/driver/mailtrap"

const email = createEmail({
  driver: mailtrap({ apiKey: process.env.MAILTRAP_API_TOKEN! }),
})
```

`apiKey` is sent as Mailtrap `Api-Token` header. A `User-Agent` is set by default (`unemail/mailtrap`).

## Sandbox

Email Sandbox testing uses a different API surface. For agent/IDE workflows, see [mailtrap/mailtrap-mcp](https://github.com/mailtrap/mailtrap-mcp); not included in this driver.

## Test plan

- [x] `pnpm test test/driver/mailtrap.test.ts`
- [x] Template mapping covered in `test/driver/templates.test.ts`
- [x] lint + typecheck pass

## Affiliation

Contributed by Mailtrap engineering. Happy to adjust naming, flags, or tests to match project conventions.


Made with [Cursor](https://cursor.com)