### PR TITLE
feat: mailtrap driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,24 @@ console.log(data.id) // data: EmailResult — TS narrows after the error check
 Every driver implements the same contract, so swapping providers is a
 one-line change.
 
+### Mailtrap (production + Email Sandbox)
+
+```ts
+import mailtrap from "unemail/driver/mailtrap"
+
+const email = createEmail({
+  driver: mailtrap({
+    apiKey: process.env.MAILTRAP_API_KEY!,
+    inboxId: process.env.MAILTRAP_INBOX_ID,
+    sandbox: process.env.MAILTRAP_USE_SANDBOX === "true",
+  }),
+})
+
+await email.send({ from: "a@b.com", to: "c@d.com", subject: "Test", text: "hi", sandbox: true })
+```
+
+See [docs/drivers.md](docs/drivers.md) for production vs sandbox routing.
+
 ## Message streams (Postmark-style)
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ console.log(data.id) // data: EmailResult — TS narrows after the error check
 Every driver implements the same contract, so swapping providers is a
 one-line change.
 
-### Mailtrap (production + Email Sandbox)
+### Mailtrap (Email API + Email Sandbox)
 
 ```ts
 import mailtrap from "unemail/driver/mailtrap"
@@ -87,7 +87,7 @@ const email = createEmail({
 await email.send({ from: "a@b.com", to: "c@d.com", subject: "Test", text: "hi", sandbox: true })
 ```
 
-See [docs/drivers.md](docs/drivers.md) for production vs sandbox routing.
+See [docs/drivers.md](docs/drivers.md) for Email API vs sandbox routing.
 
 ## Message streams (Postmark-style)
 

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@
 
 ## Design goals
 
-| Goal                         | How `unemail` delivers                                                                                                                                                    |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **One API, many transports** | `createEmail({ driver })` — 15+ built-in drivers (SMTP, Resend, SES, Postmark, SendGrid, Mailgun, Brevo, MailerSend, Loops, Zeptomail, MailChannels, Cloudflare Email, …) |
-| **Cross-runtime**            | Node, Bun, Deno, Cloudflare Workers, browser — core is zero-dep and Web-API only. No `axios`, ever.                                                                       |
-| **Compliance-ready**         | RFC 8058 one-click List-Unsubscribe, DKIM + ARC signing, suppression/preference stores, DMARC + TLS-RPT + ARF parsers                                                     |
-| **Resilient by default**     | Idempotency, retry w/ jitter, per-provider rate-limit, circuit breaker, dedupe, dead-letter, provider fallback                                                            |
-| **Unified observability**    | Structured logging, OpenTelemetry, Prometheus metrics, normalized `EmailEvent` stream across send + webhook paths                                                         |
-| **Modern DX**                | `{ data, error }` Result discriminated union, typed `Address` primitive, `react:`/`mjml:`/`handlebars:`/`liquid:` props                                                   |
-| **Testing-first**            | `createTestEmail()` with inbox + `waitFor` + 5 Vitest matchers + snapshot helper                                                                                          |
+| Goal                         | How `unemail` delivers                                                                                                                                                              |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **One API, many transports** | `createEmail({ driver })` — 15+ built-in drivers (SMTP, Resend, SES, Postmark, SendGrid, Mailgun, Mailtrap, Brevo, MailerSend, Loops, Zeptomail, MailChannels, Cloudflare Email, …) |
+| **Cross-runtime**            | Node, Bun, Deno, Cloudflare Workers, browser — core is zero-dep and Web-API only. No `axios`, ever.                                                                                 |
+| **Compliance-ready**         | RFC 8058 one-click List-Unsubscribe, DKIM + ARC signing, suppression/preference stores, DMARC + TLS-RPT + ARF parsers                                                               |
+| **Resilient by default**     | Idempotency, retry w/ jitter, per-provider rate-limit, circuit breaker, dedupe, dead-letter, provider fallback                                                                      |
+| **Unified observability**    | Structured logging, OpenTelemetry, Prometheus metrics, normalized `EmailEvent` stream across send + webhook paths                                                                   |
+| **Modern DX**                | `{ data, error }` Result discriminated union, typed `Address` primitive, `react:`/`mjml:`/`handlebars:`/`liquid:` props                                                             |
+| **Testing-first**            | `createTestEmail()` with inbox + `waitFor` + 5 Vitest matchers + snapshot helper                                                                                                    |
 
 ## Install
 

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -25,6 +25,35 @@ touch it again; swapping providers is a one-line change.
 | `unemail/driver/cloudflare-email` | CF Workers binding |      ✓      |    –    |     –      |      –      |     –     |  –   |    –    |
 | `unemail/driver/http`             | all                |  (custom)   |    –    |  (custom)  |      –      |     –     |  –   |    –    |
 
+### Mailtrap (production + Email Sandbox)
+
+The Mailtrap driver uses one API token for both environments. Production sends
+go to `send.api.mailtrap.io`; Email Sandbox (test inbox capture) uses
+`sandbox.api.mailtrap.io` with your inbox ID in the path.
+
+```ts
+import { createEmail } from "unemail"
+import mailtrap from "unemail/driver/mailtrap"
+
+const email = createEmail({
+  driver: mailtrap({
+    apiKey: process.env.MAILTRAP_API_KEY!,
+    inboxId: process.env.MAILTRAP_INBOX_ID,
+    sandbox: process.env.MAILTRAP_USE_SANDBOX === "true",
+  }),
+})
+
+// Sandbox (captured in test inbox)
+await email.send({ from: "a@b.com", to: "c@d.com", subject: "x", text: "hi", sandbox: true })
+
+// Production
+await email.send({ from: "a@verified.com", to: "c@d.com", subject: "x", text: "hi" })
+```
+
+Set `msg.sandbox` per message to override the driver default. `sendBatch`
+works in both modes; all messages in one batch must target the same environment.
+Sandbox sends require `inboxId` (from `mailtrap.io/sandboxes/{id}`).
+
 ### Meta drivers
 
 These wrap other drivers:

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -25,9 +25,9 @@ touch it again; swapping providers is a one-line change.
 | `unemail/driver/cloudflare-email` | CF Workers binding |      ✓      |    –    |     –      |      –      |     –     |  –   |    –    |
 | `unemail/driver/http`             | all                |  (custom)   |    –    |  (custom)  |      –      |     –     |  –   |    –    |
 
-### Mailtrap (production + Email Sandbox)
+### Mailtrap (Email API + Email Sandbox)
 
-The Mailtrap driver uses one API token for both environments. Production sends
+The Mailtrap driver uses one API token for both environments. Email API sends
 go to `send.api.mailtrap.io`; Email Sandbox (test inbox capture) uses
 `sandbox.api.mailtrap.io` with your inbox ID in the path.
 
@@ -46,7 +46,7 @@ const email = createEmail({
 // Sandbox (captured in test inbox)
 await email.send({ from: "a@b.com", to: "c@d.com", subject: "x", text: "hi", sandbox: true })
 
-// Production
+// Email API
 await email.send({ from: "a@verified.com", to: "c@d.com", subject: "x", text: "hi" })
 ```
 

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -16,6 +16,7 @@ touch it again; swapping providers is a one-line change.
 | `unemail/driver/ses`              | all (Web-Crypto)   |      ✓      | ✓ (seq) |     –      |      –      |     –     |  ✓   |    –    |
 | `unemail/driver/sendgrid`         | all                |      ✓      |    –    |     ✓      |      –      |     ✓     |  ✓   |    –    |
 | `unemail/driver/mailgun`          | all                |      ✓      |    –    |     ✓      |      –      |     –     |  ✓   |    –    |
+| `unemail/driver/mailtrap`         | all                |      ✓      |    ✓    |     –      |      –      |     ✓     |  ✓   |    –    |
 | `unemail/driver/brevo`            | all                |      ✓      |    –    |     ✓      |      –      |     ✓     |  ✓   |    –    |
 | `unemail/driver/mailersend`       | all                |      ✓      |    ✓    |     ✓      |      –      |     –     |  ✓   |    –    |
 | `unemail/driver/loops`            | all                |      –      |    –    |     –      |      –      |     ✓     |  ✓   |    –    |

--- a/jsr.json
+++ b/jsr.json
@@ -11,6 +11,7 @@
     "./driver/zeptomail": "./src/driver/zeptomail.ts",
     "./driver/sendgrid": "./src/driver/sendgrid.ts",
     "./driver/mailgun": "./src/driver/mailgun.ts",
+    "./driver/mailtrap": "./src/driver/mailtrap.ts",
     "./driver/brevo": "./src/driver/brevo.ts",
     "./driver/mailersend": "./src/driver/mailersend.ts",
     "./driver/loops": "./src/driver/loops.ts",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "mailcrab",
     "mailersend",
     "mailgun",
+    "mailtrap",
     "mjml",
     "postal-mime",
     "postmark",
@@ -91,6 +92,10 @@
     "./driver/mailgun": {
       "types": "./dist/driver/mailgun.d.mts",
       "default": "./dist/driver/mailgun.mjs"
+    },
+    "./driver/mailtrap": {
+      "types": "./dist/driver/mailtrap.d.mts",
+      "default": "./dist/driver/mailtrap.mjs"
     },
     "./driver/brevo": {
       "types": "./dist/driver/brevo.d.mts",

--- a/src/driver/_http.ts
+++ b/src/driver/_http.ts
@@ -2,7 +2,7 @@ import type { Result } from "../types.ts"
 import { createError, toEmailError } from "../errors.ts"
 
 /** Thin wrapper around `fetch` used by every HTTP-based driver (Resend,
- *  Postmark, SendGrid, Mailgun, Brevo, MailerSend, Loops, Zeptomail,
+ *  Postmark, SendGrid, Mailgun, Mailtrap, Brevo, MailerSend, Loops, Zeptomail,
  *  MailChannels, HTTP). Handles JSON encoding, response parsing, and
  *  mapping HTTP status codes to our `EmailErrorCode` taxonomy.
  *

--- a/src/driver/mailtrap.ts
+++ b/src/driver/mailtrap.ts
@@ -12,14 +12,25 @@ import { normalizeAddresses } from "../_normalize.ts"
 import { createError, createRequiredError } from "../errors.ts"
 import { httpJson } from "./_http.ts"
 
+/** Mailtrap Email API driver — production sending and Email Sandbox testing
+ *  with the same API token. Mirrors the official SDK env pattern:
+ *  \`MAILTRAP_API_KEY\` → \`apiKey\`, \`MAILTRAP_USE_SANDBOX\` → \`sandbox\`,
+ *  \`MAILTRAP_INBOX_ID\` → \`inboxId\`. */
 export interface MailtrapDriverOptions {
   apiKey: string
+  /** Production send API base. Default \`https://send.api.mailtrap.io\`. */
   endpoint?: string
   fetch?: typeof fetch
   /** Used when no \`tags\` entry has \`name: "category"\`. */
   defaultCategory?: string
   /** Mailtrap edge protection may block requests without a User-Agent. */
   userAgent?: string
+  /** Default sandbox mode when \`msg.sandbox\` is unset. */
+  sandbox?: boolean
+  /** Sandbox inbox ID (from mailtrap.io/sandboxes/{id}). Required for sandbox sends. */
+  inboxId?: number | string
+  /** Sandbox API base. Default \`https://sandbox.api.mailtrap.io\`. */
+  sandboxEndpoint?: string
 }
 
 interface MailtrapSendSuccess {
@@ -42,12 +53,14 @@ interface MailtrapBatchSuccess {
 
 const DRIVER = "mailtrap"
 const DEFAULT_ENDPOINT = "https://send.api.mailtrap.io"
+const DEFAULT_SANDBOX_ENDPOINT = "https://sandbox.api.mailtrap.io"
 
 const mailtrap: DriverFactory<MailtrapDriverOptions> = defineDriver<MailtrapDriverOptions>(
   (options) => {
     if (!options?.apiKey) throw createRequiredError(DRIVER, "apiKey")
 
-    const endpoint = options.endpoint ?? DEFAULT_ENDPOINT
+    const sendEndpoint = options.endpoint ?? DEFAULT_ENDPOINT
+    const sandboxEndpoint = options.sandboxEndpoint ?? DEFAULT_SANDBOX_ENDPOINT
     const fetchImpl = options.fetch ?? globalThis.fetch
     if (typeof fetchImpl !== "function")
       throw createError(DRIVER, "INVALID_OPTIONS", "fetch is unavailable; pass `fetch` explicitly")
@@ -69,6 +82,7 @@ const mailtrap: DriverFactory<MailtrapDriverOptions> = defineDriver<MailtrapDriv
         text: true,
         batch: true,
         templates: true,
+        tagging: true,
         replyTo: true,
         customHeaders: true,
       },
@@ -81,11 +95,15 @@ const mailtrap: DriverFactory<MailtrapDriverOptions> = defineDriver<MailtrapDriv
         const unsupported = rejectUnsupported(msg)
         if (unsupported) return unsupported
 
+        const useSandbox = resolveSandboxMode(msg, options)
+        const inboxErr = requireInboxIdForSandbox(useSandbox, options)
+        if (inboxErr) return inboxErr as Result<EmailResult>
+
         const payload = buildPayload(msg, defaultCategory)
         const res = await httpJson({
           fetch: fetchImpl,
           driver: DRIVER,
-          url: `${endpoint}/api/send`,
+          url: resolveApiUrl(useSandbox, "send", options, sendEndpoint, sandboxEndpoint),
           headers: mailtrapHeaders(),
           body: payload,
           classifyError: classifyMailtrapError,
@@ -101,13 +119,20 @@ const mailtrap: DriverFactory<MailtrapDriverOptions> = defineDriver<MailtrapDriv
           if (unsupported) return unsupported as Result<ReadonlyArray<EmailResult>>
         }
 
+        const mixed = validateBatchSandboxModes(msgs, options)
+        if (mixed) return mixed as Result<ReadonlyArray<EmailResult>>
+
+        const useSandbox = resolveSandboxMode(msgs[0]!, options)
+        const inboxErr = requireInboxIdForSandbox(useSandbox, options)
+        if (inboxErr) return inboxErr as Result<ReadonlyArray<EmailResult>>
+
         const payload = {
           requests: msgs.map((m) => buildPayload(m, defaultCategory)),
         }
         const res = await httpJson({
           fetch: fetchImpl,
           driver: DRIVER,
-          url: `${endpoint}/api/batch`,
+          url: resolveApiUrl(useSandbox, "batch", options, sendEndpoint, sandboxEndpoint),
           headers: mailtrapHeaders(),
           body: payload,
           classifyError: classifyMailtrapError,
@@ -156,6 +181,69 @@ const mailtrap: DriverFactory<MailtrapDriverOptions> = defineDriver<MailtrapDriv
 )
 
 export default mailtrap
+
+function resolveSandboxMode(msg: EmailMessage, options: MailtrapDriverOptions): boolean {
+  return msg.sandbox ?? options.sandbox ?? false
+}
+
+function isValidInboxId(inboxId: number | string | undefined): boolean {
+  if (inboxId === undefined || inboxId === null) return false
+  if (typeof inboxId === "number") return true
+  return String(inboxId).trim().length > 0
+}
+
+function requireInboxIdForSandbox(
+  useSandbox: boolean,
+  options: MailtrapDriverOptions,
+): Result<null> | null {
+  if (!useSandbox) return null
+  if (!isValidInboxId(options.inboxId)) {
+    return {
+      data: null,
+      error: createError(
+        DRIVER,
+        "INVALID_OPTIONS",
+        "`inboxId` is required for Mailtrap Email Sandbox",
+        { retryable: false },
+      ),
+    }
+  }
+  return null
+}
+
+function resolveApiUrl(
+  useSandbox: boolean,
+  kind: "send" | "batch",
+  options: MailtrapDriverOptions,
+  sendEndpoint: string,
+  sandboxEndpoint: string,
+): string {
+  const host = useSandbox ? sandboxEndpoint : sendEndpoint
+  const suffix = useSandbox && isValidInboxId(options.inboxId) ? `/${options.inboxId}` : ""
+  return `${host}/api/${kind}${suffix}`
+}
+
+function validateBatchSandboxModes(
+  msgs: ReadonlyArray<EmailMessage>,
+  options: MailtrapDriverOptions,
+): Result<null> | null {
+  if (msgs.length === 0) return null
+  const first = resolveSandboxMode(msgs[0]!, options)
+  for (let i = 1; i < msgs.length; i++) {
+    if (resolveSandboxMode(msgs[i]!, options) !== first) {
+      return {
+        data: null,
+        error: createError(
+          DRIVER,
+          "INVALID_OPTIONS",
+          "mixed sandbox and production messages in one batch",
+          { retryable: false },
+        ),
+      }
+    }
+  }
+  return null
+}
 
 function rejectUnsupported(msg: EmailMessage): Result<EmailResult> | null {
   if (msg.scheduledAt) {

--- a/src/driver/mailtrap.ts
+++ b/src/driver/mailtrap.ts
@@ -1,0 +1,303 @@
+import type {
+  Attachment,
+  DriverFactory,
+  EmailAddress,
+  EmailMessage,
+  EmailResult,
+  EmailTag,
+  Result,
+} from "../types.ts"
+import { defineDriver } from "../_define.ts"
+import { normalizeAddresses } from "../_normalize.ts"
+import { createError, createRequiredError } from "../errors.ts"
+import { httpJson } from "./_http.ts"
+
+export interface MailtrapDriverOptions {
+  apiKey: string
+  endpoint?: string
+  fetch?: typeof fetch
+  /** Used when no \`tags\` entry has \`name: "category"\`. */
+  defaultCategory?: string
+  /** Mailtrap edge protection may block requests without a User-Agent. */
+  userAgent?: string
+}
+
+interface MailtrapSendSuccess {
+  success?: boolean
+  message_ids?: string[]
+  errors?: string[]
+}
+
+interface MailtrapBatchItemResponse {
+  success?: boolean
+  message_ids?: string[]
+  errors?: string[]
+}
+
+interface MailtrapBatchSuccess {
+  success?: boolean
+  responses?: MailtrapBatchItemResponse[]
+  errors?: string[]
+}
+
+const DRIVER = "mailtrap"
+const DEFAULT_ENDPOINT = "https://send.api.mailtrap.io"
+
+const mailtrap: DriverFactory<MailtrapDriverOptions> = defineDriver<MailtrapDriverOptions>(
+  (options) => {
+    if (!options?.apiKey) throw createRequiredError(DRIVER, "apiKey")
+
+    const endpoint = options.endpoint ?? DEFAULT_ENDPOINT
+    const fetchImpl = options.fetch ?? globalThis.fetch
+    if (typeof fetchImpl !== "function")
+      throw createError(DRIVER, "INVALID_OPTIONS", "fetch is unavailable; pass `fetch` explicitly")
+
+    const defaultCategory = options.defaultCategory ?? "transactional"
+    const userAgent = options.userAgent ?? "unemail/mailtrap"
+
+    const mailtrapHeaders = (): Record<string, string> => ({
+      "api-token": options.apiKey,
+      "user-agent": userAgent,
+    })
+
+    return {
+      name: DRIVER,
+      options,
+      flags: {
+        attachments: true,
+        html: true,
+        text: true,
+        batch: true,
+        templates: true,
+        replyTo: true,
+        customHeaders: true,
+      },
+
+      async isAvailable() {
+        return Boolean(options.apiKey)
+      },
+
+      async send(msg) {
+        const unsupported = rejectUnsupported(msg)
+        if (unsupported) return unsupported
+
+        const payload = buildPayload(msg, defaultCategory)
+        const res = await httpJson({
+          fetch: fetchImpl,
+          driver: DRIVER,
+          url: `${endpoint}/api/send`,
+          headers: mailtrapHeaders(),
+          body: payload,
+          classifyError: classifyMailtrapError,
+        })
+        if (res.error) return res as Result<EmailResult>
+        return parseSendSuccess(res.data)
+      },
+
+      async sendBatch(msgs) {
+        if (msgs.length === 0) return { data: [], error: null }
+        for (const msg of msgs) {
+          const unsupported = rejectUnsupported(msg)
+          if (unsupported) return unsupported as Result<ReadonlyArray<EmailResult>>
+        }
+
+        const payload = {
+          requests: msgs.map((m) => buildPayload(m, defaultCategory)),
+        }
+        const res = await httpJson({
+          fetch: fetchImpl,
+          driver: DRIVER,
+          url: `${endpoint}/api/batch`,
+          headers: mailtrapHeaders(),
+          body: payload,
+          classifyError: classifyMailtrapError,
+        })
+        if (res.error) return res as never
+
+        const body = (res.data ?? {}) as MailtrapBatchSuccess
+        if (body.success === false) {
+          return {
+            data: null,
+            error: createError(
+              DRIVER,
+              "PROVIDER",
+              formatErrors(body.errors) ?? "batch request failed",
+              { cause: body },
+            ),
+          }
+        }
+
+        const responses = body.responses ?? []
+        for (let i = 0; i < responses.length; i++) {
+          const item = responses[i]
+          if (item?.success === false) {
+            return {
+              data: null,
+              error: createError(
+                DRIVER,
+                "PROVIDER",
+                formatErrors(item.errors) || `batch item ${i} failed`,
+                { cause: item },
+              ),
+            }
+          }
+        }
+
+        const results: EmailResult[] = responses.map((item, i) => ({
+          id: item?.message_ids?.[0] ?? `mailtrap_${Date.now().toString(36)}_${i}`,
+          driver: DRIVER,
+          at: new Date(),
+          provider: item as unknown as Record<string, unknown>,
+        }))
+        return { data: results, error: null }
+      },
+    }
+  },
+)
+
+export default mailtrap
+
+function rejectUnsupported(msg: EmailMessage): Result<EmailResult> | null {
+  if (msg.scheduledAt) {
+    return {
+      data: null,
+      error: createError(DRIVER, "UNSUPPORTED", "scheduling is not supported by Mailtrap", {
+        retryable: false,
+      }),
+    }
+  }
+  return null
+}
+
+function parseSendSuccess(data: unknown): Result<EmailResult> {
+  const body = (data ?? {}) as MailtrapSendSuccess
+  if (body.success === false) {
+    return {
+      data: null,
+      error: createError(DRIVER, "PROVIDER", formatErrors(body.errors) ?? "send failed", {
+        cause: body,
+      }),
+    }
+  }
+  const id = body.message_ids?.[0] ?? `mailtrap_${Date.now().toString(36)}`
+  return {
+    data: {
+      id,
+      driver: DRIVER,
+      at: new Date(),
+      provider: body as Record<string, unknown>,
+    },
+    error: null,
+  }
+}
+
+function classifyMailtrapError(
+  status: number,
+  body: unknown,
+): {
+  code: "AUTH" | "RATE_LIMIT" | "NETWORK" | "PROVIDER"
+  retryable?: boolean
+  message?: string
+} | null {
+  const record = body && typeof body === "object" ? (body as Record<string, unknown>) : null
+  const errors = record?.errors
+  const message =
+    formatErrors(Array.isArray(errors) ? (errors as string[]) : undefined) ??
+    (typeof record?.message === "string" ? record.message : null)
+
+  if (status === 401 || status === 403) {
+    return { code: "AUTH", retryable: false, message: message ?? undefined }
+  }
+  if (status === 429) {
+    return { code: "RATE_LIMIT", retryable: true, message: message ?? undefined }
+  }
+  if (status >= 500) {
+    return { code: "NETWORK", retryable: true, message: message ?? undefined }
+  }
+  if (message) return { code: "PROVIDER", retryable: false, message }
+  return null
+}
+
+function formatErrors(errors: string[] | undefined): string | null {
+  if (!errors?.length) return null
+  return errors.join("; ")
+}
+
+function buildPayload(msg: EmailMessage, defaultCategory: string): Record<string, unknown> {
+  const from = normalizeAddresses(msg.from)[0]
+  if (!from) throw createError(DRIVER, "INVALID_OPTIONS", "`from` is required")
+
+  const payload: Record<string, unknown> = {
+    from: toMailtrapAddress(from),
+    to: normalizeAddresses(msg.to).map(toMailtrapAddress),
+    subject: msg.subject,
+  }
+  if (msg.cc) payload.cc = normalizeAddresses(msg.cc).map(toMailtrapAddress)
+  if (msg.bcc) payload.bcc = normalizeAddresses(msg.bcc).map(toMailtrapAddress)
+  if (msg.replyTo) {
+    const r = normalizeAddresses(msg.replyTo)[0]
+    if (r) payload.reply_to = toMailtrapAddress(r)
+  }
+  if (msg.text) payload.text = msg.text
+  if (msg.html) payload.html = msg.html
+  if (msg.headers) payload.headers = msg.headers
+  if (msg.attachments?.length) payload.attachments = msg.attachments.map(toMailtrapAttachment)
+
+  const customVars: Record<string, string> = {}
+  if (msg.metadata) {
+    for (const [k, v] of Object.entries(msg.metadata)) customVars[k] = String(v)
+  }
+  if (msg.tags?.length) {
+    for (const tag of msg.tags) {
+      if (tag.name === "category") continue
+      customVars[`tag_${tag.name}`] = tag.value ?? ""
+    }
+  }
+  if (Object.keys(customVars).length) payload.custom_variables = customVars
+
+  payload.category = resolveCategory(msg.tags, defaultCategory)
+
+  if (msg.template) {
+    if (msg.template.id) payload.template_uuid = msg.template.id
+    if (msg.template.variables) payload.template_variables = { ...msg.template.variables }
+  }
+
+  if (!msg.template && !msg.text && !msg.html) {
+    throw createError(DRIVER, "INVALID_OPTIONS", "`text`, `html`, or `template` is required")
+  }
+
+  return payload
+}
+
+function resolveCategory(tags: ReadonlyArray<EmailTag> | undefined, fallback: string): string {
+  const cat = tags?.find((t) => t.name === "category")
+  if (cat?.value) return cat.value
+  if (cat?.name === "category" && !cat.value) return fallback
+  return fallback
+}
+
+function toMailtrapAddress(a: EmailAddress): Record<string, string> {
+  return a.name ? { email: a.email, name: a.name } : { email: a.email }
+}
+
+function toMailtrapAttachment(a: Attachment): Record<string, unknown> {
+  const content = typeof a.content === "string" ? a.content : bytesToBase64(a.content)
+  const out: Record<string, unknown> = {
+    content,
+    filename: a.filename,
+  }
+  if (a.contentType) out.type = a.contentType
+  if (a.disposition) out.disposition = a.disposition
+  if (a.cid) out.content_id = a.cid
+  return out
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  const g = globalThis as {
+    Buffer?: { from: (b: Uint8Array) => { toString: (e: string) => string } }
+  }
+  if (g.Buffer) return g.Buffer.from(bytes).toString("base64")
+  let binary = ""
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary)
+}

--- a/src/driver/mailtrap.ts
+++ b/src/driver/mailtrap.ts
@@ -12,13 +12,13 @@ import { normalizeAddresses } from "../_normalize.ts"
 import { createError, createRequiredError } from "../errors.ts"
 import { httpJson } from "./_http.ts"
 
-/** Mailtrap Email API driver — production sending and Email Sandbox testing
+/** Mailtrap driver — Email API sending and Email Sandbox testing
  *  with the same API token. Mirrors the official SDK env pattern:
  *  \`MAILTRAP_API_KEY\` → \`apiKey\`, \`MAILTRAP_USE_SANDBOX\` → \`sandbox\`,
  *  \`MAILTRAP_INBOX_ID\` → \`inboxId\`. */
 export interface MailtrapDriverOptions {
   apiKey: string
-  /** Production send API base. Default \`https://send.api.mailtrap.io\`. */
+  /** Email API base. Default \`https://send.api.mailtrap.io\`. */
   endpoint?: string
   fetch?: typeof fetch
   /** Used when no \`tags\` entry has \`name: "category"\`. */
@@ -236,7 +236,7 @@ function validateBatchSandboxModes(
         error: createError(
           DRIVER,
           "INVALID_OPTIONS",
-          "mixed sandbox and production messages in one batch",
+          "mixed Email Sandbox and Email API messages in one batch",
           { retryable: false },
         ),
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,8 @@ export interface EmailMessage {
   /** Run this send in sandbox / test mode. Mapped per-driver:
    *  - Mailgun `o:testmode`, SendGrid `mail_settings.sandbox_mode`,
    *    SES configuration sets, Postmark test-stream.
+   *  - Mailtrap: routes to Email Sandbox API (`sandbox.api.mailtrap.io/.../{inboxId}`)
+   *    when true; requires driver `inboxId`. Not the same as SendGrid/Mailgun test flags.
    *  Drivers without sandbox support raise `UNSUPPORTED`. */
   sandbox?: boolean
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,7 +88,8 @@ export interface EmailMessage {
    *  - Mailgun `o:testmode`, SendGrid `mail_settings.sandbox_mode`,
    *    SES configuration sets, Postmark test-stream.
    *  - Mailtrap: routes to Email Sandbox API (`sandbox.api.mailtrap.io/.../{inboxId}`)
-   *    when true; requires driver `inboxId`. Not the same as SendGrid/Mailgun test flags.
+   *    when true; Email API uses `send.api.mailtrap.io`. Requires driver `inboxId` for sandbox.
+   *    Not the same as SendGrid/Mailgun test flags.
    *  Drivers without sandbox support raise `UNSUPPORTED`. */
   sandbox?: boolean
 

--- a/test/driver/mailtrap.test.ts
+++ b/test/driver/mailtrap.test.ts
@@ -329,7 +329,7 @@ describe("mailtrap driver", () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it("sendBatch rejects mixed sandbox and production messages", async () => {
+  it("sendBatch rejects mixed Email Sandbox and Email API messages", async () => {
     const fetchMock = vi.fn()
     const email = createEmail({
       driver: mailtrap({
@@ -343,7 +343,7 @@ describe("mailtrap driver", () => {
       { from: "a@b.com", to: "y@y.com", subject: "2", text: "x", sandbox: false },
     ])
     expect(error?.code).toBe("INVALID_OPTIONS")
-    expect(error?.message).toContain("mixed sandbox")
+    expect(error?.message).toContain("mixed Email Sandbox")
     expect(fetchMock).not.toHaveBeenCalled()
   })
 

--- a/test/driver/mailtrap.test.ts
+++ b/test/driver/mailtrap.test.ts
@@ -171,6 +171,182 @@ describe("mailtrap driver", () => {
     expect(body.requests).toHaveLength(2)
   })
 
+  it("routes sandbox send to sandbox.api with inboxId in path", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ success: true, message_ids: ["sb_1"] }))
+    const email = createEmail({
+      driver: mailtrap({
+        apiKey: "token",
+        inboxId: 2564102,
+        fetch: fetchMock as unknown as typeof fetch,
+      }),
+    })
+    await email.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "x",
+      text: "x",
+      sandbox: true,
+    })
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe("https://sandbox.api.mailtrap.io/api/send/2564102")
+    const headers = init.headers as Record<string, string>
+    expect(headers["api-token"]).toBe("token")
+    const body = JSON.parse(init.body as string)
+    expect(body.sandbox).toBeUndefined()
+  })
+
+  it("uses driver sandbox default when msg.sandbox is unset", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ success: true, message_ids: ["x"] }))
+    const email = createEmail({
+      driver: mailtrap({
+        apiKey: "k",
+        sandbox: true,
+        inboxId: 100,
+        fetch: fetchMock as unknown as typeof fetch,
+      }),
+    })
+    await email.send({ from: "a@b.com", to: "c@d.com", subject: "x", text: "x" })
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toBe("https://sandbox.api.mailtrap.io/api/send/100")
+  })
+
+  it("msg.sandbox false overrides driver sandbox default", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ success: true, message_ids: ["x"] }))
+    const email = createEmail({
+      driver: mailtrap({
+        apiKey: "k",
+        sandbox: true,
+        inboxId: 100,
+        fetch: fetchMock as unknown as typeof fetch,
+      }),
+    })
+    await email.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "x",
+      text: "x",
+      sandbox: false,
+    })
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toBe("https://send.api.mailtrap.io/api/send")
+  })
+
+  it("returns INVALID_OPTIONS for sandbox send without inboxId", async () => {
+    const fetchMock = vi.fn()
+    const email = createEmail({
+      driver: mailtrap({ apiKey: "k", fetch: fetchMock as unknown as typeof fetch }),
+    })
+    const { error } = await email.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "x",
+      text: "x",
+      sandbox: true,
+    })
+    expect(error?.code).toBe("INVALID_OPTIONS")
+    expect(error?.message).toContain("inboxId")
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("returns INVALID_OPTIONS for empty string inboxId in sandbox", async () => {
+    const fetchMock = vi.fn()
+    const email = createEmail({
+      driver: mailtrap({
+        apiKey: "k",
+        inboxId: "  ",
+        fetch: fetchMock as unknown as typeof fetch,
+      }),
+    })
+    const { error } = await email.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "x",
+      text: "x",
+      sandbox: true,
+    })
+    expect(error?.code).toBe("INVALID_OPTIONS")
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("sendBatch routes to sandbox batch URL", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        success: true,
+        responses: [{ success: true, message_ids: ["a"] }],
+      }),
+    )
+    const email = createEmail({
+      driver: mailtrap({
+        apiKey: "k",
+        inboxId: 2564102,
+        fetch: fetchMock as unknown as typeof fetch,
+      }),
+    })
+    await email.sendBatch([
+      { from: "a@b.com", to: "x@y.com", subject: "1", text: "x", sandbox: true },
+    ])
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toBe("https://sandbox.api.mailtrap.io/api/batch/2564102")
+  })
+
+  it("sendBatch uses driver sandbox default", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        success: true,
+        responses: [
+          { success: true, message_ids: ["a"] },
+          { success: true, message_ids: ["b"] },
+        ],
+      }),
+    )
+    const email = createEmail({
+      driver: mailtrap({
+        apiKey: "k",
+        sandbox: true,
+        inboxId: 100,
+        fetch: fetchMock as unknown as typeof fetch,
+      }),
+    })
+    await email.sendBatch([
+      { from: "a@b.com", to: "x@y.com", subject: "1", text: "x" },
+      { from: "a@b.com", to: "y@y.com", subject: "2", text: "x" },
+    ])
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toBe("https://sandbox.api.mailtrap.io/api/batch/100")
+  })
+
+  it("sendBatch returns INVALID_OPTIONS without inboxId in sandbox", async () => {
+    const fetchMock = vi.fn()
+    const email = createEmail({
+      driver: mailtrap({ apiKey: "k", fetch: fetchMock as unknown as typeof fetch }),
+    })
+    const { error } = await email.sendBatch([
+      { from: "a@b.com", to: "x@y.com", subject: "1", text: "x", sandbox: true },
+    ])
+    expect(error?.code).toBe("INVALID_OPTIONS")
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("sendBatch rejects mixed sandbox and production messages", async () => {
+    const fetchMock = vi.fn()
+    const email = createEmail({
+      driver: mailtrap({
+        apiKey: "k",
+        inboxId: 100,
+        fetch: fetchMock as unknown as typeof fetch,
+      }),
+    })
+    const { error } = await email.sendBatch([
+      { from: "a@b.com", to: "x@y.com", subject: "1", text: "x", sandbox: true },
+      { from: "a@b.com", to: "y@y.com", subject: "2", text: "x", sandbox: false },
+    ])
+    expect(error?.code).toBe("INVALID_OPTIONS")
+    expect(error?.message).toContain("mixed sandbox")
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it("sendBatch fails when a batch item has success false", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       jsonResponse({

--- a/test/driver/mailtrap.test.ts
+++ b/test/driver/mailtrap.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest"
+import { createEmail } from "../../src/index.ts"
+import mailtrap from "../../src/driver/mailtrap.ts"
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+describe("mailtrap driver", () => {
+  it("POSTs /api/send with Api-Token and address shape", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ success: true, message_ids: ["mt_1"] }))
+    const email = createEmail({
+      driver: mailtrap({ apiKey: "token", fetch: fetchMock as unknown as typeof fetch }),
+    })
+    const { data, error } = await email.send({
+      from: "Acme <hi@acme.com>",
+      to: "user@example.com",
+      subject: "hi",
+      text: "hello",
+    })
+    expect(error).toBeNull()
+    expect(data?.id).toBe("mt_1")
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe("https://send.api.mailtrap.io/api/send")
+    const headers = init.headers as Record<string, string>
+    expect(headers["api-token"]).toBe("token")
+    expect(headers["user-agent"]).toBe("unemail/mailtrap")
+    const body = JSON.parse(init.body as string)
+    expect(body.from).toEqual({ email: "hi@acme.com", name: "Acme" })
+    expect(body.to).toEqual([{ email: "user@example.com" }])
+    expect(body.category).toBe("transactional")
+  })
+
+  it("maps category tag and extra tags to custom_variables", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ success: true, message_ids: ["x"] }))
+    const email = createEmail({
+      driver: mailtrap({ apiKey: "k", fetch: fetchMock as unknown as typeof fetch }),
+    })
+    await email.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "x",
+      text: "x",
+      tags: [
+        { name: "category", value: "password-reset" },
+        { name: "tenant", value: "acme" },
+      ],
+    })
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(init.body as string)
+    expect(body.category).toBe("password-reset")
+    expect(body.custom_variables).toEqual({ tag_tenant: "acme" })
+  })
+
+  it("uses defaultCategory when no category tag", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ success: true, message_ids: ["x"] }))
+    const email = createEmail({
+      driver: mailtrap({
+        apiKey: "k",
+        defaultCategory: "notifications",
+        fetch: fetchMock as unknown as typeof fetch,
+      }),
+    })
+    await email.send({ from: "a@b.com", to: "c@d.com", subject: "x", text: "x" })
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(init.body as string)
+    expect(body.category).toBe("notifications")
+  })
+
+  it("rejects missing apiKey at factory time", () => {
+    expect(() => mailtrap({} as { apiKey: string })).toThrow(/apiKey/)
+  })
+
+  it("maps 401 to AUTH", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ success: false, errors: ["Unauthorized"] }, 401))
+    const email = createEmail({
+      driver: mailtrap({ apiKey: "k", fetch: fetchMock as unknown as typeof fetch }),
+    })
+    const { error } = await email.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "x",
+      text: "x",
+    })
+    expect(error?.code).toBe("AUTH")
+    expect(error?.retryable).toBe(false)
+  })
+
+  it("maps 429 to RATE_LIMIT", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ success: false, errors: ["Too many requests"] }, 429))
+    const email = createEmail({
+      driver: mailtrap({ apiKey: "k", fetch: fetchMock as unknown as typeof fetch }),
+    })
+    const { error } = await email.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "x",
+      text: "x",
+    })
+    expect(error?.code).toBe("RATE_LIMIT")
+    expect(error?.retryable).toBe(true)
+  })
+
+  it("returns PROVIDER when HTTP 200 but success is false", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ success: false, errors: ["Invalid from"] }))
+    const email = createEmail({
+      driver: mailtrap({ apiKey: "k", fetch: fetchMock as unknown as typeof fetch }),
+    })
+    const { error } = await email.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "x",
+      text: "x",
+    })
+    expect(error?.code).toBe("PROVIDER")
+    expect(error?.message).toContain("Invalid from")
+  })
+
+  it("returns UNSUPPORTED for scheduledAt", async () => {
+    const fetchMock = vi.fn()
+    const email = createEmail({
+      driver: mailtrap({ apiKey: "k", fetch: fetchMock as unknown as typeof fetch }),
+    })
+    const { error } = await email.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "x",
+      text: "x",
+      scheduledAt: new Date(),
+    })
+    expect(error?.code).toBe("UNSUPPORTED")
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("sendBatch POSTs /api/batch with requests array", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        success: true,
+        responses: [
+          { success: true, message_ids: ["a"] },
+          { success: true, message_ids: ["b"] },
+        ],
+      }),
+    )
+    const email = createEmail({
+      driver: mailtrap({ apiKey: "k", fetch: fetchMock as unknown as typeof fetch }),
+    })
+    const { data, error } = await email.sendBatch([
+      { from: "a@b.com", to: "x@y.com", subject: "1", text: "x" },
+      { from: "a@b.com", to: "y@y.com", subject: "2", text: "x" },
+    ])
+    expect(error).toBeNull()
+    expect(data).toHaveLength(2)
+    expect(data?.[0]?.id).toBe("a")
+    expect(data?.[1]?.id).toBe("b")
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toBe("https://send.api.mailtrap.io/api/batch")
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(init.body as string)
+    expect(body.requests).toHaveLength(2)
+  })
+
+  it("sendBatch fails when a batch item has success false", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        success: true,
+        responses: [
+          { success: true, message_ids: ["a"] },
+          { success: false, errors: ["bad"] },
+        ],
+      }),
+    )
+    const email = createEmail({
+      driver: mailtrap({ apiKey: "k", fetch: fetchMock as unknown as typeof fetch }),
+    })
+    const { error } = await email.sendBatch([
+      { from: "a@b.com", to: "x@y.com", subject: "1", text: "x" },
+      { from: "a@b.com", to: "y@y.com", subject: "2", text: "x" },
+    ])
+    expect(error?.code).toBe("PROVIDER")
+  })
+})

--- a/test/driver/templates.test.ts
+++ b/test/driver/templates.test.ts
@@ -7,6 +7,7 @@ import brevo from "../../src/driver/brevo.ts"
 import mailersend from "../../src/driver/mailersend.ts"
 import loops from "../../src/driver/loops.ts"
 import zeptomail from "../../src/driver/zeptomail.ts"
+import mailtrap from "../../src/driver/mailtrap.ts"
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -101,6 +102,18 @@ describe("msg.template pass-through across drivers", () => {
     const body = JSON.parse(init.body as string)
     expect(body.transactionalId).toBe("tpl-1")
     expect(body.dataVariables).toEqual({ name: "Ada" })
+  })
+
+  it("mailtrap maps to template_uuid + template_variables", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ success: true, message_ids: ["m"] }))
+    const email = createEmail({
+      driver: mailtrap({ apiKey: "k", fetch: fetchMock as unknown as typeof fetch }),
+    })
+    await email.send(baseMsg)
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(init.body as string)
+    expect(body.template_uuid).toBe("tpl-1")
+    expect(body.template_variables).toEqual({ name: "Ada" })
   })
 
   it("zeptomail maps to template_key + merge_info", async () => {

--- a/test/driver/tracking-sandbox.test.ts
+++ b/test/driver/tracking-sandbox.test.ts
@@ -3,6 +3,7 @@ import { createEmail } from "../../src/index.ts"
 import sendgrid from "../../src/driver/sendgrid.ts"
 import mailgun from "../../src/driver/mailgun.ts"
 import postmark from "../../src/driver/postmark.ts"
+import mailtrap from "../../src/driver/mailtrap.ts"
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -60,6 +61,32 @@ describe("per-message tracking / sandbox / metadata", () => {
     expect(form.get("o:tracking-opens")).toBe("yes")
     expect(form.get("o:tracking-clicks")).toBe("yes")
     expect(form.get("v:tenant")).toBe("acme")
+  })
+
+  it("mailtrap sandbox switches API host, not payload flag", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ success: true, message_ids: ["mt_1"] }))
+    const email = createEmail({
+      driver: mailtrap({
+        apiKey: "k",
+        inboxId: 42,
+        fetch: fetchMock as unknown as typeof fetch,
+      }),
+    })
+    await email.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "x",
+      text: "x",
+      sandbox: true,
+      metadata: { tenant: "acme" },
+    })
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe("https://sandbox.api.mailtrap.io/api/send/42")
+    const body = JSON.parse(init.body as string)
+    expect(body.sandbox).toBeUndefined()
+    expect(body.custom_variables).toEqual({ tenant: "acme" })
   })
 
   it("postmark maps TrackOpens, TrackLinks, Metadata, and first tag → Tag", async () => {


### PR DESCRIPTION
## Summary

Adds `unemail/driver/mailtrap` — one driver for Mailtrap **Email API** and **Email Sandbox**, same API token, switched via `msg.sandbox` + `inboxId`.

- Production: `send.api.mailtrap.io` (`/api/send`, `/api/batch`)
- Sandbox: `sandbox.api.mailtrap.io` (`/api/send/{inboxId}`, `/api/batch/{inboxId}`)
- Maps templates, attachments, headers, reply-to, category/tags
- Mocked tests for routing, validation, and batch edge cases
- Docs: `docs/drivers.md` subsection + README snippet

Closes #96