### PR TITLE
feat(driver): add Cloudflare Email Service (Email Sending)

### DIFF
--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -6,24 +6,25 @@ touch it again; swapping providers is a one-line change.
 
 ## Built-in drivers
 
-| Sub-path                          | Runtime            | Attachments |  Batch  | Scheduling | Idempotency | Templates | Tags | Streams |
-| --------------------------------- | ------------------ | :---------: | :-----: | :--------: | :---------: | :-------: | :--: | :-----: |
-| `unemail/driver/mock`             | all                |      ✓      |    ✓    |     ✓      |      ✓      |     –     |  ✓   |    –    |
-| `unemail/driver/smtp`             | Node + Bun         |      ✓      | ✓ (seq) |     –      |      –      |     –     |  –   |    –    |
-| `unemail/driver/mailcrab`         | Node (local only)  |      ✓      |    ✓    |     –      |      –      |     –     |  –   |    –    |
-| `unemail/driver/resend`           | all                |      ✓      |    ✓    |     ✓      |      ✓      |     ✓     |  ✓   |    –    |
-| `unemail/driver/postmark`         | all                |      ✓      |    ✓    |     –      |      –      |     ✓     |  ✓   |    ✓    |
-| `unemail/driver/ses`              | all (Web-Crypto)   |      ✓      | ✓ (seq) |     –      |      –      |     –     |  ✓   |    –    |
-| `unemail/driver/sendgrid`         | all                |      ✓      |    –    |     ✓      |      –      |     ✓     |  ✓   |    –    |
-| `unemail/driver/mailgun`          | all                |      ✓      |    –    |     ✓      |      –      |     –     |  ✓   |    –    |
-| `unemail/driver/mailtrap`         | all                |      ✓      |    ✓    |     –      |      –      |     ✓     |  ✓   |    –    |
-| `unemail/driver/brevo`            | all                |      ✓      |    –    |     ✓      |      –      |     ✓     |  ✓   |    –    |
-| `unemail/driver/mailersend`       | all                |      ✓      |    ✓    |     ✓      |      –      |     –     |  ✓   |    –    |
-| `unemail/driver/loops`            | all                |      –      |    –    |     –      |      –      |     ✓     |  ✓   |    –    |
-| `unemail/driver/zeptomail`        | all                |      ✓      |    –    |     –      |      –      |     –     |  –   |    –    |
-| `unemail/driver/mailchannels`     | all (CF Workers)   |      ✓      |    –    |     –      |      –      |     –     |  –   |    –    |
-| `unemail/driver/cloudflare-email` | CF Workers binding |      ✓      |    –    |     –      |      –      |     –     |  –   |    –    |
-| `unemail/driver/http`             | all                |  (custom)   |    –    |  (custom)  |      –      |     –     |  –   |    –    |
+| Sub-path                                  | Runtime            | Attachments |  Batch  | Scheduling | Idempotency | Templates | Tags | Streams |
+| ----------------------------------------- | ------------------ | :---------: | :-----: | :--------: | :---------: | :-------: | :--: | :-----: |
+| `unemail/driver/mock`                     | all                |      ✓      |    ✓    |     ✓      |      ✓      |     –     |  ✓   |    –    |
+| `unemail/driver/smtp`                     | Node + Bun         |      ✓      | ✓ (seq) |     –      |      –      |     –     |  –   |    –    |
+| `unemail/driver/mailcrab`                 | Node (local only)  |      ✓      |    ✓    |     –      |      –      |     –     |  –   |    –    |
+| `unemail/driver/resend`                   | all                |      ✓      |    ✓    |     ✓      |      ✓      |     ✓     |  ✓   |    –    |
+| `unemail/driver/postmark`                 | all                |      ✓      |    ✓    |     –      |      –      |     ✓     |  ✓   |    ✓    |
+| `unemail/driver/ses`                      | all (Web-Crypto)   |      ✓      | ✓ (seq) |     –      |      –      |     –     |  ✓   |    –    |
+| `unemail/driver/sendgrid`                 | all                |      ✓      |    –    |     ✓      |      –      |     ✓     |  ✓   |    –    |
+| `unemail/driver/mailgun`                  | all                |      ✓      |    –    |     ✓      |      –      |     –     |  ✓   |    –    |
+| `unemail/driver/mailtrap`                 | all                |      ✓      |    ✓    |     –      |      –      |     ✓     |  ✓   |    –    |
+| `unemail/driver/brevo`                    | all                |      ✓      |    –    |     ✓      |      –      |     ✓     |  ✓   |    –    |
+| `unemail/driver/mailersend`               | all                |      ✓      |    ✓    |     ✓      |      –      |     –     |  ✓   |    –    |
+| `unemail/driver/loops`                    | all                |      –      |    –    |     –      |      –      |     ✓     |  ✓   |    –    |
+| `unemail/driver/zeptomail`                | all                |      ✓      |    –    |     –      |      –      |     –     |  –   |    –    |
+| `unemail/driver/mailchannels`             | all (CF Workers)   |      ✓      |    –    |     –      |      –      |     –     |  –   |    –    |
+| `unemail/driver/cloudflare-email`         | CF Workers binding |      ✓      |    –    |     –      |      –      |     –     |  –   |    –    |
+| `unemail/driver/cloudflare-email-service` | CF Workers binding |      ✓      |    –    |     –      |      –      |     –     |  –   |    –    |
+| `unemail/driver/http`                     | all                |  (custom)   |    –    |  (custom)  |      –      |     –     |  –   |    –    |
 
 ### Mailtrap (Email API + Email Sandbox)
 
@@ -53,6 +54,43 @@ await email.send({ from: "a@verified.com", to: "c@d.com", subject: "x", text: "h
 Set `msg.sandbox` per message to override the driver default. `sendBatch`
 works in both modes; all messages in one batch must target the same environment.
 Sandbox sends require `inboxId` (from `mailtrap.io/sandboxes/{id}`).
+
+### Cloudflare: Email Routing vs Email Service
+
+Cloudflare exposes two send APIs on the same `send_email` binding, so there are
+two drivers:
+
+- `unemail/driver/cloudflare-email` — **Email Routing**. Builds raw RFC 5322 and
+  hands it to `EmailMessage` from the virtual `cloudflare:email` module. Single
+  recipient per send, by construction.
+- `unemail/driver/cloudflare-email-service` — **Email Service** (Email Sending).
+  Passes structured fields. No ambient global, no virtual module, no MIME
+  builder in your bundle; multiple recipients in one call.
+
+```ts
+import { createEmail } from "unemail"
+import cloudflareEmailService from "unemail/driver/cloudflare-email-service"
+
+export default {
+  async fetch(req: Request, env: Env) {
+    const email = createEmail({ driver: cloudflareEmailService({ binding: env.EMAIL }) })
+    await email.send({
+      from: { email: "welcome@yourdomain.com", name: "Acme" },
+      to: ["a@example.com", "b@example.com"],
+      subject: "Welcome",
+      html: "<h1>Welcome</h1>",
+      text: "Welcome",
+    })
+    return new Response("ok")
+  },
+}
+```
+
+Needs `"send_email": [{ "name": "EMAIL" }]` in `wrangler.jsonc` and a sender
+domain onboarded with `wrangler email sending enable <domain>`. Combined
+`to` + `cc` + `bcc` is capped at 50 addresses per send by the provider; the
+binding's `E_*` errors are mapped onto the [error taxonomy](#error-taxonomy),
+so rate limits stay retryable while validation failures do not.
 
 ### Meta drivers
 

--- a/jsr.json
+++ b/jsr.json
@@ -17,6 +17,7 @@
     "./driver/loops": "./src/driver/loops.ts",
     "./driver/mailchannels": "./src/driver/mailchannels.ts",
     "./driver/cloudflare-email": "./src/driver/cloudflare-email.ts",
+    "./driver/cloudflare-email-service": "./src/driver/cloudflare-email-service.ts",
     "./driver/mailcrab": "./src/driver/mailcrab.ts",
     "./driver/resend": "./src/driver/resend.ts",
     "./driver/fallback": "./src/driver/fallback.ts",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,10 @@
       "types": "./dist/driver/cloudflare-email.d.mts",
       "default": "./dist/driver/cloudflare-email.mjs"
     },
+    "./driver/cloudflare-email-service": {
+      "types": "./dist/driver/cloudflare-email-service.d.mts",
+      "default": "./dist/driver/cloudflare-email-service.mjs"
+    },
     "./driver/mailcrab": {
       "types": "./dist/driver/mailcrab.d.mts",
       "default": "./dist/driver/mailcrab.mjs"

--- a/src/driver/cloudflare-email-service.ts
+++ b/src/driver/cloudflare-email-service.ts
@@ -1,0 +1,169 @@
+import type { Attachment, DriverFactory, EmailErrorCode, EmailResult, Result } from "../types.ts"
+import { defineDriver } from "../_define.ts"
+import { createError, createRequiredError, toEmailError } from "../errors.ts"
+import { normalizeAddresses } from "../_normalize.ts"
+
+/** Cloudflare **Email Service** (Email Sending) outbound binding.
+ *
+ *  Distinct from `unemail/driver/cloudflare-email`, which targets the older
+ *  **Email Routing** API: that one constructs `EmailMessage` from the virtual
+ *  `cloudflare:email` module and hands the binding raw RFC 5322 text. Email
+ *  Service takes structured fields on the same `send_email` binding, so this
+ *  driver needs no ambient global, no virtual module, and no MIME builder.
+ *  Both are kept — pick the one matching the API your binding speaks.
+ *
+ *  ```ts
+ *  export default {
+ *    async fetch(req, env) {
+ *      const email = createEmail({ driver: cloudflareEmailService({ binding: env.EMAIL }) })
+ *      await email.send({ from, to, subject, html, text })
+ *    }
+ *  }
+ *  ```
+ *
+ *  Requires a `send_email` binding in `wrangler.jsonc` and a sender domain
+ *  onboarded via `wrangler email sending enable <domain>`. */
+export interface CloudflareEmailServiceDriverOptions {
+  binding: CloudflareEmailServiceBinding
+}
+
+export interface CloudflareEmailServiceBinding {
+  send: (message: CloudflareEmailServiceMessage) => Promise<CloudflareEmailSendResult | void>
+}
+
+/** Structured payload accepted by the binding. Declared locally so the driver
+ *  depends on neither `@cloudflare/workers-types` nor `cloudflare:email` —
+ *  when those types are available, prefer them at the call site. */
+export interface CloudflareEmailServiceMessage {
+  from: { email: string; name?: string }
+  to: string[]
+  subject: string
+  text?: string
+  html?: string
+  cc?: string[]
+  bcc?: string[]
+  replyTo?: string
+  headers?: Record<string, string>
+  attachments?: CloudflareEmailServiceAttachment[]
+}
+
+export interface CloudflareEmailServiceAttachment {
+  content: string | Uint8Array
+  filename: string
+  type?: string
+  disposition?: "attachment" | "inline"
+  contentId?: string
+}
+
+export interface CloudflareEmailSendResult {
+  messageId?: string
+}
+
+const DRIVER = "cloudflare-email-service"
+
+/** The binding throws `Error`s carrying an `E_*` `code`. Map them onto our
+ *  taxonomy so `retryable` is meaningful — otherwise the retry middleware
+ *  would keep re-sending messages that a validation fix, not a retry, cures. */
+const ERROR_CODES: Record<string, EmailErrorCode> = {
+  E_VALIDATION_ERROR: "INVALID_OPTIONS",
+  E_FIELD_MISSING: "INVALID_OPTIONS",
+  E_TOO_MANY_RECIPIENTS: "INVALID_OPTIONS",
+  E_CONTENT_TOO_LARGE: "INVALID_OPTIONS",
+  E_HEADER_NOT_ALLOWED: "INVALID_OPTIONS",
+  E_HEADER_USE_API_FIELD: "INVALID_OPTIONS",
+  E_HEADER_VALUE_INVALID: "INVALID_OPTIONS",
+  E_HEADER_VALUE_TOO_LONG: "INVALID_OPTIONS",
+  E_HEADER_NAME_INVALID: "INVALID_OPTIONS",
+  E_HEADERS_TOO_LARGE: "INVALID_OPTIONS",
+  E_HEADERS_TOO_MANY: "INVALID_OPTIONS",
+  E_SENDER_NOT_VERIFIED: "AUTH",
+  E_SENDER_DOMAIN_NOT_AVAILABLE: "AUTH",
+  E_RECIPIENT_NOT_ALLOWED: "AUTH",
+  E_RATE_LIMIT_EXCEEDED: "RATE_LIMIT",
+  E_DAILY_LIMIT_EXCEEDED: "RATE_LIMIT",
+  E_DELIVERY_FAILED: "NETWORK",
+  E_INTERNAL_SERVER_ERROR: "NETWORK",
+}
+
+function toDriverError(err: unknown) {
+  const code = ERROR_CODES[String((err as { code?: unknown })?.code ?? "")]
+  if (!code) return toEmailError(DRIVER, err)
+  return createError(DRIVER, code, (err as Error).message, { cause: err })
+}
+
+/** Email Service takes structured attachments rather than MIME parts, so the
+ *  mapping is a rename: `contentType` → `type`, `cid` → `contentId`. */
+function toCloudflareAttachment(file: Attachment): CloudflareEmailServiceAttachment {
+  return {
+    content: file.content,
+    filename: file.filename,
+    type: file.contentType,
+    disposition: file.disposition ?? (file.cid ? "inline" : "attachment"),
+    contentId: file.cid,
+  }
+}
+
+const cloudflareEmailService: DriverFactory<CloudflareEmailServiceDriverOptions> =
+  defineDriver<CloudflareEmailServiceDriverOptions>((options) => {
+    if (!options?.binding) throw createRequiredError(DRIVER, "binding")
+
+    return {
+      name: DRIVER,
+      options,
+      flags: {
+        html: true,
+        text: true,
+        attachments: true,
+        customHeaders: true,
+        replyTo: true,
+      },
+
+      async isAvailable() {
+        return true
+      },
+
+      async send(msg): Promise<Result<EmailResult>> {
+        try {
+          const from = normalizeAddresses(msg.from)[0]
+          const to = normalizeAddresses(msg.to).map((addr) => addr.email)
+          if (!from || !to.length)
+            return {
+              data: null,
+              error: createError(DRIVER, "INVALID_OPTIONS", "`from` and `to` are required"),
+            }
+
+          const cc = normalizeAddresses(msg.cc).map((addr) => addr.email)
+          const bcc = normalizeAddresses(msg.bcc).map((addr) => addr.email)
+          const replyTo = normalizeAddresses(msg.replyTo)[0]
+
+          const result = await options.binding.send({
+            from: { email: from.email, name: from.name },
+            to,
+            subject: msg.subject,
+            text: msg.text,
+            html: msg.html,
+            cc: cc.length ? cc : undefined,
+            bcc: bcc.length ? bcc : undefined,
+            replyTo: replyTo?.email,
+            headers: msg.headers,
+            attachments: msg.attachments?.length
+              ? msg.attachments.map(toCloudflareAttachment)
+              : undefined,
+          })
+
+          return {
+            data: {
+              id: result?.messageId ?? "",
+              driver: DRIVER,
+              at: new Date(),
+            },
+            error: null,
+          }
+        } catch (err) {
+          return { data: null, error: toDriverError(err) }
+        }
+      },
+    }
+  })
+
+export default cloudflareEmailService

--- a/test/driver/cloudflare-email-service.test.ts
+++ b/test/driver/cloudflare-email-service.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest"
+import { createEmail } from "../../src/index.ts"
+import cloudflareEmailService from "../../src/driver/cloudflare-email-service.ts"
+import type { CloudflareEmailServiceMessage } from "../../src/driver/cloudflare-email-service.ts"
+
+function sent(send: ReturnType<typeof vi.fn>): CloudflareEmailServiceMessage {
+  return send.mock.calls[0]?.[0] as CloudflareEmailServiceMessage
+}
+
+/** Mirrors the binding's failure mode: a plain `Error` carrying an `E_*` code. */
+function bindingError(code: string, message: string): Error {
+  return Object.assign(new Error(message), { code })
+}
+
+describe("cloudflare-email-service driver", () => {
+  it("sends structured fields, not MIME", async () => {
+    const send = vi.fn().mockResolvedValue({ messageId: "msg-1" })
+    const email = createEmail({ driver: cloudflareEmailService({ binding: { send } }) })
+
+    const { data, error } = await email.send({
+      from: "Acme <sender@acme.com>",
+      to: "user@example.com",
+      subject: "hi",
+      text: "hello",
+      html: "<p>hello</p>",
+    })
+
+    expect(error).toBeNull()
+    expect(data?.id).toBe("msg-1")
+    expect(data?.driver).toBe("cloudflare-email-service")
+    expect(sent(send)).toMatchObject({
+      from: { email: "sender@acme.com", name: "Acme" },
+      to: ["user@example.com"],
+      subject: "hi",
+      text: "hello",
+      html: "<p>hello</p>",
+    })
+  })
+
+  it("sends multiple recipients in one call", async () => {
+    const send = vi.fn().mockResolvedValue({ messageId: "msg-2" })
+    const email = createEmail({ driver: cloudflareEmailService({ binding: { send } }) })
+
+    await email.send({
+      from: "sender@acme.com",
+      to: ["a@example.com", "b@example.com"],
+      cc: "cc@example.com",
+      bcc: ["bcc@example.com"],
+      replyTo: "Support <support@acme.com>",
+      subject: "x",
+      text: "x",
+    })
+
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(sent(send)).toMatchObject({
+      to: ["a@example.com", "b@example.com"],
+      cc: ["cc@example.com"],
+      bcc: ["bcc@example.com"],
+      replyTo: "support@acme.com",
+    })
+  })
+
+  it("omits cc, bcc and attachments when unused", async () => {
+    const send = vi.fn().mockResolvedValue({ messageId: "msg-3" })
+    const email = createEmail({ driver: cloudflareEmailService({ binding: { send } }) })
+
+    await email.send({ from: "a@b.com", to: "c@d.com", subject: "x", text: "x" })
+
+    const payload = sent(send)
+    expect(payload.cc).toBeUndefined()
+    expect(payload.bcc).toBeUndefined()
+    expect(payload.attachments).toBeUndefined()
+  })
+
+  it("maps attachments onto the provider's field names", async () => {
+    const send = vi.fn().mockResolvedValue({ messageId: "msg-4" })
+    const email = createEmail({ driver: cloudflareEmailService({ binding: { send } }) })
+
+    await email.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "x",
+      text: "x",
+      attachments: [
+        { filename: "report.csv", content: "a,b", contentType: "text/csv" },
+        { filename: "logo.png", content: "iVBOR", contentType: "image/png", cid: "logo" },
+      ],
+    })
+
+    expect(sent(send).attachments).toEqual([
+      {
+        filename: "report.csv",
+        content: "a,b",
+        type: "text/csv",
+        disposition: "attachment",
+        contentId: undefined,
+      },
+      {
+        filename: "logo.png",
+        content: "iVBOR",
+        type: "image/png",
+        disposition: "inline",
+        contentId: "logo",
+      },
+    ])
+  })
+
+  it("forwards custom headers", async () => {
+    const send = vi.fn().mockResolvedValue({ messageId: "msg-5" })
+    const email = createEmail({ driver: cloudflareEmailService({ binding: { send } }) })
+
+    await email.send({
+      from: "a@b.com",
+      to: "c@d.com",
+      subject: "x",
+      text: "x",
+      headers: { "X-Campaign-ID": "welcome" },
+    })
+
+    expect(sent(send).headers).toMatchObject({ "X-Campaign-ID": "welcome" })
+  })
+
+  it("requires a binding", () => {
+    expect(() => cloudflareEmailService({} as never)).toThrow(/binding/)
+  })
+
+  it("classifies validation failures as non-retryable", async () => {
+    const send = vi
+      .fn()
+      .mockRejectedValue(bindingError("E_SENDER_NOT_VERIFIED", "domain not onboarded"))
+    const email = createEmail({ driver: cloudflareEmailService({ binding: { send } }) })
+
+    const { error } = await email.send({ from: "a@b.com", to: "c@d.com", subject: "x", text: "x" })
+
+    expect(error?.code).toBe("AUTH")
+    expect(error?.retryable).toBe(false)
+    expect(error?.message).toMatch(/domain not onboarded/)
+  })
+
+  it("classifies rate limits as retryable", async () => {
+    const send = vi.fn().mockRejectedValue(bindingError("E_RATE_LIMIT_EXCEEDED", "slow down"))
+    const email = createEmail({ driver: cloudflareEmailService({ binding: { send } }) })
+
+    const { error } = await email.send({ from: "a@b.com", to: "c@d.com", subject: "x", text: "x" })
+
+    expect(error?.code).toBe("RATE_LIMIT")
+    expect(error?.retryable).toBe(true)
+  })
+
+  it("falls back to PROVIDER for unrecognized errors", async () => {
+    const send = vi.fn().mockRejectedValue(new Error("boom"))
+    const email = createEmail({ driver: cloudflareEmailService({ binding: { send } }) })
+
+    const { error } = await email.send({ from: "a@b.com", to: "c@d.com", subject: "x", text: "x" })
+
+    expect(error?.code).toBe("PROVIDER")
+    expect(error?.message).toMatch(/boom/)
+  })
+})


### PR DESCRIPTION
Closes #100. Opened as a draft because one design question is still open — see [Shape](#shape) below.

## What

Adds `unemail/driver/cloudflare-email-service` for Cloudflare's [Email Service](https://developers.cloudflare.com/email-service/) (Email Sending), alongside the existing `cloudflare-email` driver.

The two speak different APIs on the same `send_email` binding:

|  | `cloudflare-email` (existing) | `cloudflare-email-service` (new) |
| --- | --- | --- |
| API | Email Routing | Email Service / Email Sending |
| Payload | raw RFC 5322 via `buildMime` | structured fields |
| Needs `cloudflare:email` | yes (`EmailMessage`) | no |
| Recipients per send | 1 (`normalizeAddresses(msg.to)[0]`) | many (up to 50 across to/cc/bcc) |

Practical effects: no ambient global and no virtual-module import (so no `"cloudflare:email" could not be resolved` warning in Vite dev), no `_smtp/mime` in the built module, and display names come through as structured `from: { email, name }` rather than depending on a MIME header.

Binding errors arrive as `Error`s carrying an `E_*` `code`. Those are mapped onto the existing `EmailErrorCode` taxonomy, so `retry` middleware treats `E_RATE_LIMIT_EXCEEDED` as retryable and `E_VALIDATION_ERROR` / `E_SENDER_NOT_VERIFIED` as not. Unrecognised codes fall through to `toEmailError` → `PROVIDER`, as before.

## Shape

The issue offered either a separate driver or a mode flag on the existing one, and left the choice to you. This PR takes the separate-driver route because it's non-breaking — `cloudflare-email` is untouched for Email Routing users. Happy to reshape it into a mode flag on the existing driver instead if you'd prefer; that's the reason this is a draft.

## Correction to the issue

The issue proposed omitting the `attachments` flag. That was wrong — I re-checked the current [Workers binding docs](https://developers.cloudflare.com/email-service/api/send-emails/workers-api/) and Email Service **does** accept structured attachments, so the driver supports them and maps `contentType` → `type`, `cid` → `contentId`. The issue's sketch also listed `cc`/`bcc` in `flags`, which aren't keys of `DriverFlags`; the actual flags are `html`, `text`, `attachments`, `customHeaders`, `replyTo`.

## Included

- the driver
- 9 tests (`test/driver/cloudflare-email-service.test.ts`)
- `docs/drivers.md` matrix row + a section on the Routing-vs-Service distinction
- `package.json` and `jsr.json` export entries

## Verification

`pnpm lint`, `pnpm typecheck`, `vitest run` (281 tests, 56 files), `pnpm build` and `pnpm bundle-budget` all pass locally.

One caveat, stated plainly: this surface was validated against Cloudflare's current documentation and the unemail source, and is covered by unit tests against a mock binding — but **I have not exercised the send path against a live Cloudflare binding**. Worth a second pair of eyes on the payload field names before release.
